### PR TITLE
Update Bare.tmSnippet

### DIFF
--- a/Snippets/Bare.tmSnippet
+++ b/Snippets/Bare.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>require 'ruby-processing'
+	<string>
 
 def setup
   size $1, $2


### PR DESCRIPTION
require "ruby-processing" is no longer required
